### PR TITLE
add error codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor
 _vendor*
 .DS_Store
+cover.out
+coverage.html

--- a/api/api.go
+++ b/api/api.go
@@ -1,3 +1,5 @@
+// Package api provides methods to contact the Aurora API and process
+// the given requests.
 package api
 
 // URL constants

--- a/api/backend/aurora_backend.go
+++ b/api/backend/aurora_backend.go
@@ -12,18 +12,18 @@ import (
 )
 
 const (
-	// the base URL for the backend (which is the actual service)
+	// baseURL for the backend (which is the actual service)
 	baseURL = "https://api.auroraapi.com"
 )
 
 // AuroraBackend is an implementation that actually executes requests
-// with the API server
+// with the API server.
 type AuroraBackend struct {
 	BaseURL string
 	client  *http.Client
 }
 
-// NewAuroraBackend returns an AuroraBackend
+// NewAuroraBackend returns an AuroraBackend with default configuration.
 func NewAuroraBackend() Backend {
 	return &AuroraBackend{
 		BaseURL: baseURL,
@@ -34,21 +34,23 @@ func NewAuroraBackend() Backend {
 }
 
 // NewAuroraBackendWithClient creates an AuroraBackend with the given client
+// and baseURL. This is particularly useful during testing.
 func NewAuroraBackendWithClient(baseURL string, client *http.Client) Backend {
 	return &AuroraBackend{BaseURL: baseURL, client: client}
 }
 
-// SetClient sets the http client for the backend
+// SetClient sets the http client for the backend.
 func (b *AuroraBackend) SetClient(client *http.Client) {
 	b.client = client
 }
 
-// SetBaseURL sets the base URL for the backend
+// SetBaseURL sets the base URL for the backend. This is useful if you want
+// to change the backend endpoint to a local or test deployment.
 func (b *AuroraBackend) SetBaseURL(url string) {
 	b.BaseURL = url
 }
 
-// Call implements a call to the backend
+// Call implements a call to the backend.
 func (b *AuroraBackend) Call(params *CallParams) (*http.Response, error) {
 	params.Path = fmt.Sprintf("%s%s?%s", b.BaseURL, params.Path, params.Query.Encode())
 	req, err := b.NewRequest(params)
@@ -59,7 +61,7 @@ func (b *AuroraBackend) Call(params *CallParams) (*http.Response, error) {
 	return b.Do(req)
 }
 
-// NewRequest creates an http.Request from the given parameters
+// NewRequest creates an http.Request from the given parameters.
 func (b *AuroraBackend) NewRequest(params *CallParams) (*http.Request, error) {
 	req, err := http.NewRequest(params.Method, params.Path, params.Body)
 	if err != nil {
@@ -81,7 +83,7 @@ func (b *AuroraBackend) NewRequest(params *CallParams) (*http.Request, error) {
 	return req, nil
 }
 
-// Do executes the given request
+// Do executes the given request.
 func (b *AuroraBackend) Do(req *http.Request) (*http.Response, error) {
 	res, err := b.client.Do(req)
 	if err != nil {
@@ -92,7 +94,7 @@ func (b *AuroraBackend) Do(req *http.Request) (*http.Response, error) {
 
 // handleError takes an http.Response object and assesses whether or not
 // an error occurred. If it did, it returns an error object. Otherwise it
-// returns nil
+// returns nil.
 func handleError(r *http.Response) error {
 	if r.StatusCode == http.StatusOK {
 		return nil

--- a/api/backend/backend.go
+++ b/api/backend/backend.go
@@ -1,3 +1,8 @@
+// Package backend provides a generic interface to make calls to the Aurora
+// backend. It implements it in the `AuroraBackend` struct, which actually is
+// configured to make API calls, but others can be implemented to behave
+// differently or hit a different endpoint. This is particularly useful during
+// testing.
 package backend
 
 import (
@@ -6,7 +11,7 @@ import (
 	"net/url"
 )
 
-// MultipartFile is an in-memory representation of a file to upload
+// MultipartFile is an in-memory representation of a file to upload.
 type MultipartFile struct {
 	// Name is the form field name
 	Name string
@@ -16,7 +21,7 @@ type MultipartFile struct {
 	Data []byte
 }
 
-// CallParams describe the request to send
+// CallParams describe the request to send.
 type CallParams struct {
 	// Method is one of GET, POST, PATCH, DELETE, etc.
 	Method string
@@ -36,7 +41,7 @@ type CallParams struct {
 	Credentials *Credentials
 }
 
-// Credentials are the credentials for the API request
+// Credentials for the API request.
 type Credentials struct {
 	// AppID is the appliacation ID (sent for 'X-Application-ID' header)
 	AppID string
@@ -46,7 +51,7 @@ type Credentials struct {
 	DeviceID string
 }
 
-// Backend is an interface for a general backend that executes a given request
+// Backend is an interface for a general backend that executes a given request.
 type Backend interface {
 	// Set some properties of the backend
 	SetBaseURL(url string)

--- a/api/interpret.go
+++ b/api/interpret.go
@@ -9,7 +9,7 @@ import (
 )
 
 // InterpretResponse is the response returned by the API if the text was
-// successfully able to be interpreted
+// successfully able to be interpreted.
 type InterpretResponse struct {
 	// Text is the original query
 	Text string `json:"text"`
@@ -25,7 +25,7 @@ type InterpretResponse struct {
 }
 
 // GetInterpret queries the API with the provided text and returns
-// the interpreted response
+// the interpreted response.
 func GetInterpret(c *config.Config, text string) (*InterpretResponse, error) {
 	params := &backend.CallParams{
 		Credentials: c.GetCredentials(),

--- a/api/stt.go
+++ b/api/stt.go
@@ -11,19 +11,19 @@ import (
 )
 
 // STTResponse is the response returned by the API if the speech was
-// successfully able to be transcribed
+// successfully able to be transcribed.
 type STTResponse struct {
 	Transcript string `json:"transcript"`
 }
 
 // GetSTT queries the API with the provided audio file and returns
-// a transcript of the speech
+// a transcript of the speech.
 func GetSTT(c *config.Config, audio *audio.File) (*STTResponse, error) {
 	return GetSTTFromStream(c, bytes.NewReader(audio.WAVData()))
 }
 
-// GetSTTFromStream queries the API with the provided raw WAV audio stram
-// and returns a transcript of the speech
+// GetSTTFromStream queries the API with the provided raw WAV audio stream
+// and returns a transcript of the speech.
 func GetSTTFromStream(c *config.Config, audio io.Reader) (*STTResponse, error) {
 	params := &backend.CallParams{
 		Credentials: c.GetCredentials(),

--- a/api/tts.go
+++ b/api/tts.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GetTTS calls the TTS API given some text and returns an *audio.File
-// with the audio from converting the text to speech
+// with the audio from converting the text to speech.
 func GetTTS(c *config.Config, text string) (*audio.File, error) {
 	params := &backend.CallParams{
 		Credentials: c.GetCredentials(),

--- a/audio/audiofile.go
+++ b/audio/audiofile.go
@@ -118,7 +118,6 @@ func (f *File) Play() error {
 	if err != nil {
 		return errors.NewFromErrorCodeInfo(errors.AudioFileNilStream, err.Error());
 	}
-
 	defer stream.Close()
 	defer stream.Stop()
 	stream.Start()
@@ -144,7 +143,7 @@ func (f *File) Play() error {
 		// write the converted data into the stream
 		err := stream.Write()
 		if err != nil {
-			return errors.NewFromErrorCodeInfo(errors.AudioFileNilStream, err.Error());
+			return errors.NewFromErrorCodeInfo(errors.AudioFileNotWritableStream, err.Error());
 		}
 	}
 

--- a/audio/audiofile.go
+++ b/audio/audiofile.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	_ "github.com/nkansal96/aurora-go/errors"
+	"github.com/nkansal96/aurora-go/errors"
 
 	"github.com/gordonklaus/portaudio"
 )
@@ -112,7 +112,7 @@ func (f *File) Play() error {
 	// create the audio stream to write to
 	stream, err := portaudio.OpenDefaultStream(0, int(f.AudioData.NumChannels), float64(f.AudioData.SampleRate), BufSize, buf)
 	if err != nil {
-		return err
+		return errors.NewFromErrorCodeInfo(errors.AudioFileNilStream, err.Error());
 	}
 
 	defer stream.Close()
@@ -140,7 +140,7 @@ func (f *File) Play() error {
 		// write the converted data into the stream
 		err := stream.Write()
 		if err != nil {
-			return err
+			return errors.NewFromErrorCodeInfo(errors.AudioFileNilStream, err.Error());
 		}
 	}
 

--- a/audio/audiofile.go
+++ b/audio/audiofile.go
@@ -116,7 +116,7 @@ func (f *File) Play() error {
 	// create the audio stream to write to
 	stream, err := portaudio.OpenDefaultStream(0, int(f.AudioData.NumChannels), float64(f.AudioData.SampleRate), BufSize, buf)
 	if err != nil {
-		return errors.NewFromErrorCodeInfo(errors.AudioFileNilStream, err.Error());
+		return errors.NewFromErrorCodeInfo(errors.AudioFileOutputStreamNotOpened, err.Error());
 	}
 	defer stream.Close()
 	defer stream.Stop()

--- a/audio/utils.go
+++ b/audio/utils.go
@@ -7,9 +7,10 @@ import (
 	"github.com/gordonklaus/portaudio"
 )
 
-// rms is a helper function used to calculate the RMS. This is called
-// by TrimSilent which uses RMS to determine whether the sample of audio
-// is silent
+// rms calculates the root-mean-square of a sequence of audio data. For
+// now, it assumes that the data is in 16-bit mono samples. Thus, the passed
+// value for `sampleSize` MUST be 2. This will change once we figure out
+// how to read a variable size of data during runtime.
 func rms(sampleSize int, audioData []byte) float64 {
 	sum := 0.0
 	for i := 0; i < len(audioData)-1; i += sampleSize {

--- a/audio/wav.go
+++ b/audio/wav.go
@@ -104,7 +104,7 @@ func NewWAVFromData(data []byte) (*WAV, error) {
 
 	dataLen := len(data) - i
 	if dataLen <= 0 {
-		return nil, errors.NewFromErrorCode(errors.WAVCorruptFile)
+		return nil, errors.NewFromErrorCodeInfo(errors.WAVCorruptFile, "The letters `RIFF` should exist from bytes 0 to 3 in big endian form from the start of the header to indicate that it is a RIFF header.")
 	}
 
 	// hOff is the header offset. Even though the header length is actually
@@ -119,17 +119,17 @@ func NewWAVFromData(data []byte) (*WAV, error) {
 
 	// Verifies that "WAVE" letters exist in big endian form
 	if (data[hOff+8] != 'W' || data[hOff+9] != 'A' || data[hOff+10] != 'V' || data[hOff+11] != 'E') {
-		return nil, errors.NewFromErrorCode(errors.WAVCorruptFile)
+		return nil, errors.NewFromErrorCodeInfo(errors.WAVCorruptFile, "The letters `WAVE` should exist from bytes 8 to 11 in big endian form from the start of the header to indicate that it is a WAVE format file.")
 	}
 
 	// Verifies that "fmt " letters exist in big endian form
 	if (data[hOff+12] != 'f' || data[hOff+13] != 'm' || data[hOff+14] != 't' || data[hOff+15] != ' '){
-		return nil, errors.NewFromErrorCode(errors.WAVCorruptFile)
+		return nil, errors.NewFromErrorCodeInfo(errors.WAVCorruptFile, "The letters `fmt ` should exist from bytes 12 to 15 in big endian form from the start of the header to indicate the subchunk 1 ID")
 	}	
 
 	// Verifies that the "data" letters exist in big endian form
 	if (data[hOff+36] != 'd' || data[hOff+37] != 'a' || data[hOff+38] != 't' || data[hOff+39] != 'a') {
-		return nil, errors.NewFromErrorCode(errors.WAVCorruptFile)
+		return nil, errors.NewFromErrorCodeInfo(errors.WAVCorruptFile, "The letters `data` should exist from bytes 36 to 39 in big endian form from the start of the header to indicate the subchunk 2 ID.")
 	}
 
 	numChannels := binary.LittleEndian.Uint16(data[hOff+22 : hOff+24])

--- a/audio/wav.go
+++ b/audio/wav.go
@@ -13,7 +13,8 @@ import (
 const (
 	// DefaultNumChannels is 1 (mono audio)
 	DefaultNumChannels uint16 = 1
-	DefaultSampleRate  uint32 = 16000
+	// DefaultSampleRate is 16KHz
+	DefaultSampleRate uint32 = 16000
 	// DefaultAudioFormat is 1 (raw, uncompressed PCM waveforms)
 	DefaultAudioFormat uint16 = 1
 	// DefaultBitsPerSample is 16 (2 bytes per sample).
@@ -51,8 +52,7 @@ type WAVParams struct {
 	AudioData     []byte
 }
 
-// NewWAV returns a new WAV file from the default parameters. It will never
-// return an error.
+// NewWAV returns a new, empty WAV file using the default parameters.
 func NewWAV() *WAV {
 	// create a new default WAV
 	return &WAV{
@@ -65,11 +65,8 @@ func NewWAV() *WAV {
 }
 
 // NewWAVFromParams returns a new WAV file from the passed in parameters
-// If any of the numerical parameters are 0, then it will be given the default
-// values.
+// If any of the parameters are 0, it will be given the default value.
 func NewWAVFromParams(params *WAVParams) *WAV {
-	// create a WAV from the given params
-	// use defaults from previous function if any value is 0
 	if params == nil {
 		return NewWAV()
 	}
@@ -96,7 +93,7 @@ func NewWAVFromParams(params *WAVParams) *WAV {
 
 // NewWAVFromData creates a WAV format struct from the given data buffer
 // The buffer is broken up into its respective information and that
-// information is used to create the WAV format struct
+// information is used to create the WAV.
 func NewWAVFromData(data []byte) (*WAV, error) {
 	// find the end of subchunk2id (data)
 	i := 4
@@ -134,8 +131,7 @@ func NewWAVFromData(data []byte) (*WAV, error) {
 	}, nil
 }
 
-// NewWAVFromReader takes in a reader and creates a new WAV format
-// with the given information.
+// NewWAVFromReader takes in a reader and creates a new WAV file.
 func NewWAVFromReader(reader io.Reader) (*WAV, error) {
 	b, err := ioutil.ReadAll(reader)
 	if err != nil {
@@ -197,7 +193,7 @@ func (w *WAV) AudioData() []byte {
 }
 
 // Data creates the header and data based on the WAV struct and returns
-// a fully formatted WAV file format
+// a fully formatted WAV file
 func (w *WAV) Data() []byte {
 	// find first data index
 	dataLen := len(w.audioData)

--- a/audio/wav.go
+++ b/audio/wav.go
@@ -97,6 +97,8 @@ func NewWAVFromParams(params *WAVParams) *WAV {
 // NewWAVFromData creates a WAV format struct from the given data buffer
 // The buffer is broken up into its respective information and that
 // information is used to create the WAV format struct
+
+// TODO: should be checking the checksum and things like that to make sure it isn't corrupt
 func NewWAVFromData(data []byte) (*WAV, error) {
 	// find the end of subchunk2id (data)
 	i := 4
@@ -106,10 +108,7 @@ func NewWAVFromData(data []byte) (*WAV, error) {
 
 	dataLen := len(data) - i
 	if dataLen <= 0 {
-		return nil, errors.Error{
-			Code:    "One",
-			Message: "Received WAV file with empty data",
-		}
+		return nil, errors.NewFromErrorCode(errors.WAVCorruptFile)
 	}
 
 	// hOff is the header offset. Even though the header length is actually

--- a/audio/wav_test.go
+++ b/audio/wav_test.go
@@ -41,11 +41,20 @@ func TestNewWAVFromParamsCustom(t *testing.T) {
 	require.Equal(t, 0, len(wav.AudioData()))
 }
 
+func TestNewWAVFromParamsNotSpecified(t *testing.T) {
+	// emptyAudio := make([]byte, 0)
+	wav := audio.NewWAVFromParams(nil)
+	require.Equal(t, audio.DefaultNumChannels, wav.NumChannels)
+	require.Equal(t, audio.DefaultSampleRate, wav.SampleRate)
+	require.Equal(t, audio.DefaultBitsPerSample, wav.BitsPerSample)
+	require.Equal(t, 0, len(wav.AudioData()))
+}
+
 // If some of the WAVParams are specified to be 0, then the default
 // parameters specified in the wav.go file should be given
-func TestNewWAVFromParamsNotSpecified(t *testing.T) {
+func TestNewWAVFromParamsWithZero(t *testing.T) {
 	emptyAudio := make([]byte, 0)
-	wav := audio.NewWAVFromParams(&audio.WAVParams{1, 0, 16, emptyAudio})
+	wav := audio.NewWAVFromParams(&audio.WAVParams{0, 0, 0, emptyAudio})
 	require.Equal(t, audio.DefaultNumChannels, wav.NumChannels)
 	require.Equal(t, audio.DefaultSampleRate, wav.SampleRate)
 	require.Equal(t, audio.DefaultBitsPerSample, wav.BitsPerSample)
@@ -58,6 +67,21 @@ func TestNewWAVFromData(t *testing.T) {
 	emptyWAVFile := testutils.CreateEmptyWAVFile()
 
 	wav, err := audio.NewWAVFromData(emptyWAVFile)
+	require.Nil(t, err)
+	require.Equal(t, uint16(1), wav.NumChannels)
+	require.Equal(t, uint32(44100), wav.SampleRate)
+	require.Equal(t, uint16(16), wav.BitsPerSample)
+	require.Equal(t, 0, len(wav.AudioData()))
+}
+
+// When given bytes of data where the first couple of bytes is not part of the 
+// data file, then those parts should be regarded in reader the WAV header
+func TestNewWAVFromData(t *testing.T) {
+	buff := []byte{0x12, 0x34, 0x56, 0x78};
+	emptyWAVFile := testutils.CreateEmptyWAVFile()
+	buffWith
+
+	wav, err := audio.NewWAVFromData(append(buff, emptyWAVFile))
 	require.Nil(t, err)
 	require.Equal(t, uint16(1), wav.NumChannels)
 	require.Equal(t, uint32(44100), wav.SampleRate)

--- a/audio/wav_test.go
+++ b/audio/wav_test.go
@@ -16,6 +16,9 @@ import (
 var apiErrorType *errors.APIError
 var c *config.Config
 
+// This test checks that if the NewWAV function is called, a correctly 
+// formatted struct is created with the default parameters 
+// as specified by the constants in the aduio package
 func TestNewWAV(t *testing.T) {
 	wav := audio.NewWAV()
 	require.Equal(t, audio.DefaultNumChannels, wav.NumChannels)
@@ -39,7 +42,7 @@ func TestNewWAVFromParamsCustom(t *testing.T) {
 }
 
 // If some of the WAVParams are specified to be 0, then the default
-// parameters specified in the wav.go file will be given
+// parameters specified in the wav.go file should be given
 func TestNewWAVFromParamsNotSpecified(t *testing.T) {
 	emptyAudio := make([]byte, 0)
 	wav := audio.NewWAVFromParams(&audio.WAVParams{1, 0, 16, emptyAudio})
@@ -49,6 +52,8 @@ func TestNewWAVFromParamsNotSpecified(t *testing.T) {
 	require.Equal(t, 0, len(wav.AudioData()))
 }
 
+// When given bytes of data, the information is properly parsed into a new
+// WAV struct
 func TestNewWAVFromData(t *testing.T) {
 	emptyWAVFile := testutils.CreateEmptyWAVFile()
 
@@ -60,6 +65,8 @@ func TestNewWAVFromData(t *testing.T) {
 	require.Equal(t, 0, len(wav.AudioData()))
 }
 
+// A new reader with bytes of data should be properly parsed into a new 
+// WAV struct
 func TestNewWAVFromReader(t *testing.T) {
 	emptyWAVFile := testutils.CreateEmptyWAVFile()
 	r := bytes.NewReader(emptyWAVFile)
@@ -72,6 +79,8 @@ func TestNewWAVFromReader(t *testing.T) {
 	require.Equal(t, 0, len(wav.AudioData()))
 }
 
+// If AddAudioData function is passed a set of bytes, the wav
+// structure should now contain the new data
 func TestAddAudioData(t *testing.T) {
 	emptyWAVFile := testutils.CreateEmptyWAVFile()
 
@@ -82,6 +91,20 @@ func TestAddAudioData(t *testing.T) {
 
 	require.Nil(t, err)
 	require.Equal(t, 4, len(wav.AudioData()))
+}
+
+// If AddAudioData function is called on an empty set of bytes, 
+// the wav structure should remain the same
+func TestAddAudioDataEmpty(t *testing.T) {
+	emptyWAVFile := testutils.CreateEmptyWAVFile()
+
+	audioData := make([]byte, 0)
+
+	wav, err := audio.NewWAVFromData(emptyWAVFile)
+	wav.AddAudioData(audioData)
+
+	require.Nil(t, err)
+	require.Equal(t, 0, len(wav.AudioData()))
 }
 
 func TestData(t *testing.T) {

--- a/aurora.go
+++ b/aurora.go
@@ -1,13 +1,15 @@
+// Package aurora is an SDK to interact with the Aurora API, making it
+// easy to integrate voice user interfaces into your application.
 package aurora
 
 import (
 	"github.com/nkansal96/aurora-go/config"
 )
 
-// Config is an alias for config.C so that the user can easily
+// Config is an alias for config.C so that you can easily
 // override the SDK configuation by typing something like:
 //
 //   aurora.Config.AppID    = "My ID"
 //   aurora.Config.AppToken = "My Token"
-//
+//   aurora.Config.DeviceID = "My Device"
 var Config = config.C

--- a/config/config.go
+++ b/config/config.go
@@ -1,3 +1,5 @@
+// Package config contains configuration information that is used by the
+// rest of the SDK.
 package config
 
 import (
@@ -20,13 +22,13 @@ type Config struct {
 }
 
 // GetCredentials converts the client's credentials into a struct
-// that gets passed into the backend
+// that gets passed into the backend.
 func (c *Config) GetCredentials() *backend.Credentials {
 	return &backend.Credentials{c.AppID, c.AppToken, c.DeviceID}
 }
 
 // C is an instance of the above config (with default values). It's exported
-// so that all packages can use it
+// so that all packages can use it.
 var C = &Config{
 	Backend: backend.NewAuroraBackend(),
 }

--- a/errors/api_error.go
+++ b/errors/api_error.go
@@ -21,6 +21,7 @@ type APIError struct {
 	Info string `json:"-"`
 }
 
+// Error converts the error to a human-readable, string format.
 func (e APIError) Error() string {
 	return e.Message
 }

--- a/errors/codes.go
+++ b/errors/codes.go
@@ -7,14 +7,16 @@ type ErrorCode string
 const (
 	SpeechNilAudio = "SpeechNilAudio"
 	WAVCorruptFile = "WAVCorruptFile"
-	AudioFileNilStream = "AudioFileNilStream"
+	AudioFileOutputStreamNotOpened = "AudioFileOutputStreamNotOpened"
 	AudioFileNotWritableStream = "AudioFileNotWritableStream"
 )
 
 // errorMessages converts an error code to its corresponding message
 var errorMessages = map[ErrorCode]string{
 	SpeechNilAudio: "The audio file was nil. In order to convert a Speech object to Text, it must have a valid audio file. Usually, this means you created a Speech object that wasn't created using one of the Listen methods.",
-	WAVCorruptFile: "The wav file was corrupted. The wav file sent in does not have an incorrect header. This could be due to an incorrect file passed in or the header parameters were not fully passed in.",
-	AudioFileNilStream: "The audio stream was nil. Portaudio encountered an error in creating the file stream which may be due to an incorrectly formatted RIFF header. Check the file to make sure it was not corrupted or incomplete",
-	AudioFileNotWritableStream: "The data could not be written into the stream. This may be due to the buffer not being completely written or the stream is not open. Check that the stream is open and that the buffer has been written",
+	WAVCorruptFile: "The wav file was corrupted. The wav file sent in does not have a correctly formatted RIFF header. Check the file to make sure it was not corrupted or incomplete.",
+	AudioFileOutputStreamNotOpened: "The audio stream was unable to be opened. Portaudio encountered an error in opening the file stream which is usually do to an error in connecting to the input and/or output device. ",
+	AudioFileNotWritableStream: "The data could not be written into the stream. This may be due to attempting to write to a callback stream, trying to write to an input only stream, the buffer had incorrect parameters, or the stream is not open.",
 }
+
+

--- a/errors/codes.go
+++ b/errors/codes.go
@@ -8,11 +8,13 @@ const (
 	SpeechNilAudio = "SpeechNilAudio"
 	WAVCorruptFile = "WAVCorruptFile"
 	AudioFileNilStream = "AudioFileNilStream"
+	AudioFileNotWritableStream = "AudioFileNotWritableStream"
 )
 
 // errorMessages converts an error code to its corresponding message
 var errorMessages = map[ErrorCode]string{
 	SpeechNilAudio: "The audio file was nil. In order to convert a Speech object to Text, it must have a valid audio file. Usually, this means you created a Speech object that wasn't created using one of the Listen methods.",
 	WAVCorruptFile: "The wav file was corrupted. The wav file sent in does not have an incorrect header. This could be due to an incorrect file passed in or the header parameters were not fully passed in.",
-	AudioFileNilStream: "The audio stream was nil. Portaudio encountered an error in creating the file stream.",
+	AudioFileNilStream: "The audio stream was nil. Portaudio encountered an error in creating the file stream which may be due to an incorrectly formatted RIFF header. Check the file to make sure it was not corrupted or incomplete",
+	AudioFileNotWritableStream: "The data could not be written into the stream. This may be due to the buffer not being completely written or the stream is not open. Check that the stream is open and that the buffer has been written",
 }

--- a/errors/codes.go
+++ b/errors/codes.go
@@ -6,9 +6,11 @@ type ErrorCode string
 // Define the various error codes possible
 const (
 	SpeechNilAudio = "SpeechNilAudio"
+	WAVCorruptFile = "WAVCorruptFile"
 )
 
-// errorMessages converts and error code to its corresponding message
+// errorMessages converts an error code to its corresponding message
 var errorMessages = map[ErrorCode]string{
 	SpeechNilAudio: "The audio file was nil. In order to convert a Speech object to Text, it must have a valid audio file. Usually, this means you created a Speech object that wasn't created using one of the Listen methods.",
+	WAVCorruptFile: "The wav file was corrupted. The wav file sent in does not have an incorrect header. This could be due to an incorrect file passed in or the header parameters were not fully passed in.",
 }

--- a/errors/codes.go
+++ b/errors/codes.go
@@ -14,9 +14,9 @@ const (
 // errorMessages converts an error code to its corresponding message
 var errorMessages = map[ErrorCode]string{
 	SpeechNilAudio: "The audio file was nil. In order to convert a Speech object to Text, it must have a valid audio file. Usually, this means you created a Speech object that wasn't created using one of the Listen methods.",
-	WAVCorruptFile: "The wav file was corrupted. The wav file sent in does not have a correctly formatted RIFF header. Check the file to make sure it was not corrupted or incomplete.",
-	AudioFileOutputStreamNotOpened: "The audio stream was unable to be opened. Portaudio encountered an error in opening the file stream which is usually do to an error in connecting to the input and/or output device. ",
-	AudioFileNotWritableStream: "The data could not be written into the stream. This may be due to attempting to write to a callback stream, trying to write to an input only stream, the buffer had incorrect parameters, or the stream is not open.",
+	WAVCorruptFile: "The WAV file was corrupted and did not have a correctly formatted RIFF header. Check the file to make sure it was not corrupted or incomplete.",
+	AudioFileOutputStreamNotOpened: "PortAudio encountered an error in opening the audio stream, which is usually due to an error in connecting to the input and/or output device.",
+	AudioFileNotWritableStream: "The data could not be written into the stream. You may have attempted to write to a callback stream, tried to write to an input-only stream, created a buffer with incorrect parameters, or did not open the stream at all.",
 }
 
 

--- a/errors/codes.go
+++ b/errors/codes.go
@@ -7,10 +7,12 @@ type ErrorCode string
 const (
 	SpeechNilAudio = "SpeechNilAudio"
 	WAVCorruptFile = "WAVCorruptFile"
+	AudioFileNilStream = "AudioFileNilStream"
 )
 
 // errorMessages converts an error code to its corresponding message
 var errorMessages = map[ErrorCode]string{
 	SpeechNilAudio: "The audio file was nil. In order to convert a Speech object to Text, it must have a valid audio file. Usually, this means you created a Speech object that wasn't created using one of the Listen methods.",
 	WAVCorruptFile: "The wav file was corrupted. The wav file sent in does not have an incorrect header. This could be due to an incorrect file passed in or the header parameters were not fully passed in.",
+	AudioFileNilStream: "The audio stream was nil. Portaudio encountered an error in creating the file stream.",
 }

--- a/errors/codes.go
+++ b/errors/codes.go
@@ -1,0 +1,14 @@
+package errors
+
+// ErrorCode is a code for an error
+type ErrorCode string
+
+// Define the various error codes possible
+const (
+	SpeechNilAudio = "SpeechNilAudio"
+)
+
+// errorMessages converts and error code to its corresponding message
+var errorMessages = map[ErrorCode]string{
+	SpeechNilAudio: "The audio file was nil. In order to convert a Speech object to Text, it must have a valid audio file. Usually, this means you created a Speech object that wasn't created using one of the Listen methods.",
+}

--- a/errors/error.go
+++ b/errors/error.go
@@ -1,7 +1,12 @@
+// Package error is a collection of error-related functionality that aims to
+// unify all of the errors across the SDK. Specifically, it abstracts away low
+// level errors into higher-level, easier-to-digest errors of two types: SDK
+// errors (represented by the `Error` class) and API errors (represented by the
+// `APIError` class).
 package errors
 
-// Error is a generic error that is returned when something non-API related
-// goes wrong
+// Error is a generic error that is returned when something SDK-related
+// goes wrong.
 type Error struct {
 	// Code is the specific error code (for debugging purposes)
 	Code string `json:"code,omitempty"`
@@ -13,10 +18,12 @@ type Error struct {
 	Info string `json:"-"`
 }
 
+// Error converts the error to a human-readable, string format.
 func (e Error) Error() string {
 	return e.Message
 }
 
+// NewError creates and `Error` object from the given information.
 func NewError(code string, message string, info string) *Error {
 	return &Error{
 		Code:    code,
@@ -25,6 +32,8 @@ func NewError(code string, message string, info string) *Error {
 	}
 }
 
+// NewFromErrorCode creates an `Error` object based on a predefined code and
+// message.
 func NewFromErrorCode(code ErrorCode) *Error {
 	return &Error{
 		Code:    string(code),
@@ -32,6 +41,8 @@ func NewFromErrorCode(code ErrorCode) *Error {
 	}
 }
 
+// NewFromErrorCodeInfo creates an `Error` object based on a predefined code
+// and also includes some extra information about the error.
 func NewFromErrorCodeInfo(code ErrorCode, info string) *Error {
 	return &Error{
 		Code:    string(code),

--- a/errors/error.go
+++ b/errors/error.go
@@ -17,10 +17,11 @@ func (e Error) Error() string {
 	return e.Message
 }
 
-func NewError(code string, message string) *Error {
+func NewError(code string, message string, info string) *Error {
 	return &Error{
 		Code:    code,
 		Message: message,
+		Info:    info,
 	}
 }
 
@@ -28,5 +29,13 @@ func NewFromErrorCode(code ErrorCode) *Error {
 	return &Error{
 		Code:    string(code),
 		Message: errorMessages[code],
+	}
+}
+
+func NewFromErrorCodeInfo(code ErrorCode, info string) *Error {
+	return &Error{
+		Code:    string(code),
+		Message: errorMessages[code],
+		Info:    info,
 	}
 }

--- a/errors/error.go
+++ b/errors/error.go
@@ -16,3 +16,17 @@ type Error struct {
 func (e Error) Error() string {
 	return e.Message
 }
+
+func NewError(code string, message string) *Error {
+	return &Error{
+		Code:    code,
+		Message: message,
+	}
+}
+
+func NewFromErrorCode(code ErrorCode) *Error {
+	return &Error{
+		Code:    string(code),
+		Message: errorMessages[code],
+	}
+}

--- a/speech.go
+++ b/speech.go
@@ -68,10 +68,7 @@ func NewSpeech(newAudio *audio.File) *Speech {
 // to chain and combine using high-level abstractions.
 func (t *Speech) Text() (*Text, error) {
 	if t.Audio == nil {
-		return nil, errors.Error{
-			Code:    "One",
-			Message: "The audio file was nil. In order to convert a Speech object to Text, it must have a valid audio file. Usually, this means you created a Speech object that wasn't created using one of the Listen methods.",
-		}
+		return nil, errors.NewFromErrorCode(errors.SpeechNilAudio)
 	}
 
 	response, err := api.GetSTT(Config, t.Audio)

--- a/text.go
+++ b/text.go
@@ -6,13 +6,13 @@ import (
 
 // Text encapsulates some text, whether it is obtained from STT, a user input,
 // or generated programmatically, and allows high-level operations to be
-// conducted and chained on it (like converting to speech, or calling Interpret)
+// conducted and chained on it (like converting to speech, or calling Interpret).
 type Text struct {
 	// Text is the actual text that this object encapsulates
 	Text string
 }
 
-// NewText creates a Text object from the given text
+// NewText creates a Text object from the given text.
 func NewText(text string) *Text {
 	return &Text{Text: text}
 }
@@ -30,7 +30,7 @@ func (t *Text) Speech() (*Speech, error) {
 
 // Interpret calls the Aurora Interpret service on the text encapsulated in this
 // object and converts it to an `Interpret` object, which contains the results
-// from the API calls
+// from the API call.
 func (t *Text) Interpret() (*Interpret, error) {
 	response, err := api.GetInterpret(Config, t.Text)
 	if err != nil {


### PR DESCRIPTION
This branch aims to unify the SDK errors by defining codes and messages for each one and then returning the error. See the example to start adding codes and messages in the given format.